### PR TITLE
edit space in readme to test heroku deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ There are 3 options to get postgresql installed locally [Choose one]:
     - run: `docker-compose up -d` to start up the postgresql database and pgadmin.
     - Open a browser to [pgadmin](http://localhost:5050/) and you should see the Dev server already defined.
     - If you need to start over you will need to delete the folder `$ rm -rf ./data/pg` as this is where all of the server data is stored.
-      - if the database `api-dev` was not created then start over.
+    - if the database `api-dev` was not created then start over.
 2. Download and install postgresql directly from the [main site](https://www.postgresql.org/download/)
     - make note of the port, username and password you use to setup the database.
     - Connect your client to the server manually using the values previously mentioned


### PR DESCRIPTION
### Description
Edited a single space in the readme, this was to test the heroku auto-deploy on push.

### Why was this done?
Heroku auto deploys from main, We provisioned a new production DB but no PR's have been made since that DB has been created, this PR is to test if merging into main will run the migration on the production DB