### PR TITLE
fixed seed data to not use PK, also added crud operations for recipie…

### DIFF
--- a/api/recipients/recipientsModel.js
+++ b/api/recipients/recipientsModel.js
@@ -7,12 +7,20 @@ const getById = (id) => {
   return knex('recipients').where({ recipient_id: id });
 };
 
-// COMMENTED OUT BECAUSE NOT QUITE FUNCTIONAL BUT NEARLY
-// const patchById = async (id, changes) => {
-//   return await knex('recipients').where({ recipient_id: id }).update(changes);
-// };
+const create = async (newRecipient) => {
+  const id = await knex('recipients').insert(newRecipient, 'recipient_id')
+  console.log(id)
+  return getById(id[0])
+}
+
+const update = async (id, changes) => {
+  await knex('recipients').where('recipient_id', id).update(changes);
+  return getById(id);
+};
+
 module.exports = {
   getAll,
   getById,
-  // patchById,
+  create,
+  update,
 };

--- a/api/recipients/recipientsRouter.js
+++ b/api/recipients/recipientsRouter.js
@@ -27,6 +27,49 @@ router.get('/:id', (req, res, next) => {
     });
 });
 
+router.post('/', async (req, res, next) => {
+  try{
+    console.log(req.body)
+    const newRecipient = await Recipients.create(req.body)
+    console.log(newRecipient)
+    res.status(200).json(newRecipient)
+  } catch(err){
+    next(err)
+  }
+})
+
+router.put('/:id', (req, res) => {
+  const { id } = req.params;
+  const changes = req.body;
+  Recipients.update(id, changes)
+    .then((editedEntry) => {
+      res.status(200).json(editedEntry);
+    })
+    .catch((err) => {
+      res.status(500).json({ error: err.message });
+    });
+});
+
+router.delete('/:id', (req, res) => {
+  const { id } = req.params;
+
+  Recipients.remove(id)
+    .then((count) => {
+      if (count > 0) {
+        res
+          .status(200)
+          .json({ message: `Recipient ${id} has been removed` });
+      } else {
+        res
+          .status(404)
+          .json({ message: `Recipient ${id} could not be found` });
+      }
+    })
+    .catch((err) => {
+      res.status(500).json({ error: err.message });
+    });
+});
+
 // COMMENTED OUT BECAUSE NOT QUITE FUNCTIONAL BUT NEARLY
 // update a particular field of a recipient
 // router.patch('/patch/:id', (req, res, next) => {

--- a/api/serviceEntries/serviceEntriesModel.js
+++ b/api/serviceEntries/serviceEntriesModel.js
@@ -11,7 +11,7 @@ const getById = (id) => {
 const create = async (serviceEntry) => {
   const [id] = await knex('service_entries').insert(
     serviceEntry,
-    'services_entries_id'
+    'service_entries_id'
   );
   return getById(id);
 };
@@ -21,9 +21,14 @@ const update = async (id, changes) => {
   return getById(id);
 };
 
+const remove = async (id) => {
+  return await knex('service_entries').where('service_entries_id', id).del()
+}
+
 module.exports = {
   getAll,
   getById,
   create,
   update,
+  remove
 };

--- a/api/serviceEntries/serviceEntriesRouter.js
+++ b/api/serviceEntries/serviceEntriesRouter.js
@@ -53,8 +53,7 @@ router.put('/:id', (req, res) => {
 
 router.delete('/:id', (req, res) => {
   const { id } = req.params;
-
-  DB.remove('service_entries', id)
+  ServiceEntry.remove(id)
     .then((count) => {
       if (count > 0) {
         res

--- a/data/seeds/002_programs.js
+++ b/data/seeds/002_programs.js
@@ -1,18 +1,15 @@
 const programs = [
   {
-    program_id: 1,
     name: 'Prevention',
     type: 'Prevention',
     description: 'This is the prevention program',
   },
   {
-    program_id: 2,
     name: 'Sheltering',
     type: 'Sheltering',
     description: 'This is the sheltering program',
   },
   {
-    program_id: 3,
     name: 'Aftercare',
     type: 'Aftercare',
     description: 'This is the aftercare program',

--- a/data/seeds/003_programs_managers.js
+++ b/data/seeds/003_programs_managers.js
@@ -1,16 +1,13 @@
 const assignments = [
   {
-    program_manager_id: 1,
     program_id: '1',
     profile_id: '00unr48onuAmU9sxK5d6',
   },
   {
-    program_manager_id: 2,
     program_id: '2',
     profile_id: '00unr48onuAmU9sxK5d6',
   },
   {
-    program_manager_id: 3,
     program_id: '1',
     profile_id: '00uk9lxaulDYOiB4H5d6',
   },

--- a/data/seeds/004_statuses.js
+++ b/data/seeds/004_statuses.js
@@ -1,18 +1,14 @@
 const statuses = [
   {
-    status_id: 1,
     status: 'Complete',
   },
   {
-    status_id: 2,
     status: 'In Progress',
   },
   {
-    status_id: 3,
     status: 'Needs Followup',
   },
   {
-    status_id: 4,
     status: 'Not Started',
   },
 ];

--- a/data/seeds/005_service_types.js
+++ b/data/seeds/005_service_types.js
@@ -1,18 +1,15 @@
 const service_types = [
   {
-    service_type_id: 1,
     name: 'Bus Passes',
     description: 'Provides city bus passes for work programs',
     program_id: 1,
   },
   {
-    service_type_id: 2,
     name: 'Rental Assitance',
     description: 'Provides monthly rental assistance to prevent foreclosure',
     program_id: 3,
   },
   {
-    service_type_id: 3,
     name: 'Childcare',
     description: 'Provides K-12 childcare support',
     program_id: 2,

--- a/data/seeds/006_ethnicity.js
+++ b/data/seeds/006_ethnicity.js
@@ -1,18 +1,14 @@
 const ethnicities = [
   {
-    ethnicity_id: 1,
     ethnicity: 'White',
   },
   {
-    ethnicity_id: 2,
     ethnicity: 'Hispanic',
   },
   {
-    ethnicity_id: 3,
     ethnicity: 'Asian',
   },
   {
-    ethnicity_id: 4,
     ethnicity: 'African American',
   },
 ];

--- a/data/seeds/007_recipients.js
+++ b/data/seeds/007_recipients.js
@@ -1,6 +1,5 @@
 const recipients = [
   {
-    recipient_id: 1,
     firstname: 'Michael',
     middle: 'Joseph',
     lastname: 'Smith',
@@ -12,7 +11,6 @@ const recipients = [
     mental_status: '',
   },
   {
-    recipient_id: 2,
     firstname: 'Jose',
     middle: 'Guadalupe',
     lastname: 'Gutierrez',
@@ -24,7 +22,6 @@ const recipients = [
     mental_status: '',
   },
   {
-    recipient_id: 3,
     firstname: 'Victoria',
     middle: '',
     lastname: 'Nguyen',
@@ -36,7 +33,6 @@ const recipients = [
     mental_status: '',
   },
   {
-    recipient_id: 4,
     firstname: 'Andre',
     middle: '',
     lastname: 'Jackson',

--- a/data/seeds/008_locations.js
+++ b/data/seeds/008_locations.js
@@ -1,6 +1,5 @@
 const locations = [
   {
-    location_id: 1,
     name: 'Smith Residence',
     country: 'United States of America',
     state: 'Washington',
@@ -9,7 +8,6 @@ const locations = [
     address: '123 Terrance Ave',
   },
   {
-    location_id: 2,
     name: 'California Mission',
     country: 'United States of America',
     state: 'California',
@@ -18,7 +16,6 @@ const locations = [
     address: '5828 Carson Dr',
   },
   {
-    location_id: 3,
     name: 'Massachusetts Shelter',
     country: 'United States of America',
     state: 'Massachusetts',

--- a/data/seeds/009_services_providers.js
+++ b/data/seeds/009_services_providers.js
@@ -1,21 +1,17 @@
 const providers = [
   {
-    service_provider_id: 1,
     service_type_id: 1,
     profile_id: '00uk9lxaulDYOiB4H5d6',
   },
   {
-    service_provider_id: 2,
     service_type_id: 2,
     profile_id: '00uk9lxaulDYOiB4H5d6',
   },
   {
-    service_provider_id: 3,
     service_type_id: 1,
     profile_id: '00unr8nm2sJkxkcrH5d6',
   },
   {
-    service_provider_id: 4,
     service_type_id: 3,
     profile_id: '00unr8nm2sJkxkcrH5d6',
   },

--- a/data/seeds/010_service_entries.js
+++ b/data/seeds/010_service_entries.js
@@ -2,7 +2,6 @@ const faker = require('faker');
 
 const entries = [
   {
-    service_entries_id: 1,
     service_date:'01-01-2020',
     service_time:'5:00',
     service_type_id: 1,
@@ -13,7 +12,6 @@ const entries = [
     value: 100.00,
   },
   {
-    service_entries_id: 2,
     service_date:'01-01-2020',
     service_time:'5:00',
     service_type_id: 2,
@@ -24,7 +22,6 @@ const entries = [
     value: 425.00,
   },
   {
-    service_entries_id: 3,
     service_date:'01-01-2020',
     service_time:'5:00',
     service_type_id: 3,
@@ -35,7 +32,6 @@ const entries = [
     value: 250.00,
   },
   {
-    service_entries_id: 4,
     service_date:'01-01-2020',
     service_time:'5:00',
     service_type_id: 2,

--- a/data/seeds/011_households.js
+++ b/data/seeds/011_households.js
@@ -1,27 +1,23 @@
 const households = [
   {
-    household_id: 1,
     household_name: "Smith's",
     household_size: 5,
     household_income: 42855.06,
     location_id: 1,
   },
   {
-    household_id: 2,
     household_name: "Gutierrez's",
     household_size: 3,
     household_income: 27832.02,
     location_id: 2,
   },
   {
-    household_id: 3,
     household_name: "Nguyen's",
     household_size: 2,
     household_income: 25657.12,
     location_id: 3,
   },
   {
-    household_id: 4,
     household_name: "Jacksons's",
     household_size: 4,
     household_income: 42855.06,

--- a/data/seeds/012_household_members.js
+++ b/data/seeds/012_household_members.js
@@ -1,21 +1,17 @@
 const householdMembers = [
   {
-    household_member_id: 1,
     household_id: 1,
     recipient_id: 1,
   },
   {
-    household_member_id: 2,
     household_id: 2,
     recipient_id: 2,
   },
   {
-    household_member_id: 3,
     household_id: 3,
     recipient_id: 3,
   },
   {
-    household_member_id: 4,
     household_id: 4,
     recipient_id: 4,
   },

--- a/data/seeds/014_service_notes.js
+++ b/data/seeds/014_service_notes.js
@@ -2,25 +2,21 @@ const faker = require('faker');
 
 const notes = [
   {
-    service_notes_id: 1,
     service_entries_id: 1,
     profile_id: '00unr8nm2sJkxkcrH5d6',
     service_note: faker.lorem.sentence(),
   },
   {
-    service_notes_id: 2,
     service_entries_id: 2,
     profile_id: '00unr3s3m2zHx70ck5d6',
     service_note: faker.lorem.sentence(),
   },
   {
-    service_notes_id: 3,
     service_entries_id: 3,
     profile_id: '00unr8nm2sJkxkcrH5d6',
     service_note: faker.lorem.sentence(),
   },
   {
-    service_notes_id: 4,
     service_entries_id: 4,
     profile_id: '00unr3s3m2zHx70ck5d6',
     service_note: faker.lorem.sentence(),


### PR DESCRIPTION
### Description

Me, @Diegormnv  , and @RemyVila  all troubleshot a bug throughout the day, ultimately it ended up being a mismatch of indexes in the primary keys from the seed files. This was fixed and removed from seed files, and once the bug was cleared up I was able to complete all basic crud operations on the service_entries table and all but the delete functionality on the recipients table.

### Why was this done?
Our release 1 on our roadmap involves having recipients and service_entries to have crud operations working. This bug fixes that and adds almost all crud operations needed.

Type of change
- [x]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [x]  This change requires a documentation update

Change Status
- [x]  Complete, but not tested (may need new tests)

Checklist
- [x]  My code follows the style guidelines of this project
- [x]  I have performed a self-review of my own code
- [x]  My changes generate no new warnings
- [x]  There are no merge conflicts
