### PR TITLE
updated migration and seed files to pair the households and recipient…

### DIFF
--- a/api/recipients/recipientsModel.js
+++ b/api/recipients/recipientsModel.js
@@ -2,13 +2,17 @@ const knex = require('../../data/db-config');
 const getAll = () => {
   return knex('recipients')
   .join('ethnicity', 'recipients.ethnicity_id', 'ethnicity.ethnicity_id')
-  .select('recipients.recipient_id', 'recipients.firstname', 'recipients.middle', 'recipients.lastname', 'ethnicity', 'email', 'phone', 'age', 'veteran', 'mental_status', 'created_at', 'updated_at');
+  .join('households', 'households.household_id', 'recipients.household_id')
+  .join('locations', 'locations.location_id', 'households.location_id')
+  .select('recipients.recipient_id', 'recipients.firstname', 'recipients.middle', 'recipients.lastname', 'ethnicity', 'household_name as household', 'household_size', 'household_income', 'locations.name as location', 'locations.state', 'locations.city','locations.zip', 'locations.address', 'email', 'phone', 'age', 'veteran', 'mental_status', 'recipients.created_at', 'recipients.updated_at');
 };
 
 const getById = (id) => {
   return knex('recipients').where({ recipient_id: id })
   .join('ethnicity', 'recipients.ethnicity_id', 'ethnicity.ethnicity_id')
-  .select('recipients.recipient_id', 'recipients.firstname', 'recipients.middle', 'recipients.lastname', 'ethnicity', 'email', 'phone', 'age', 'veteran', 'mental_status', 'created_at', 'updated_at').first();
+  .join('households', 'households.household_id', 'recipients.household_id')
+  .join('locations', 'locations.location_id', 'households.location_id')
+  .select('recipients.recipient_id', 'recipients.firstname', 'recipients.middle', 'recipients.lastname', 'ethnicity', 'household_name as household', 'household_size', 'household_income', 'locations.name as location', 'locations.state', 'locations.city','locations.zip', 'locations.address', 'email', 'phone', 'age', 'veteran', 'mental_status', 'recipients.created_at', 'recipients.updated_at').first();
 };
 
 const create = async (newRecipient) => {

--- a/api/serviceTypes/serviceTypeModel.js
+++ b/api/serviceTypes/serviceTypeModel.js
@@ -1,15 +1,31 @@
 const knex = require('../../data/db-config');
 
+// const findAll = async () => {
+//   return await knex('service_types')
+//     .leftJoin('service_providers', {
+//       'service_types.service_type_id': 'service_providers.service_type_id',
+//     })
+//     .leftJoin('profiles', {
+//       'service_providers.profile_id': 'profiles.profile_id',
+//     })
+//     .select(
+//       knex.raw('service_types.*, json_agg(profiles.*) as service_providers')
+//     )
+//     .groupBy('service_types.service_type_id');
+// };
 const findAll = async () => {
   return await knex('service_types')
     .leftJoin('service_providers', {
       'service_types.service_type_id': 'service_providers.service_type_id',
     })
+    .leftJoin('programs', {
+      'service_types.program_id': 'programs.program_id', 
+    })
     .leftJoin('profiles', {
       'service_providers.profile_id': 'profiles.profile_id',
     })
     .select(
-      knex.raw('service_types.*, json_agg(profiles.*) as service_providers')
+      knex.raw('service_types.service_type_id, service_types.name as service, service_types.description, array_agg(programs.name) as program, json_agg(profiles.*) as service_providers')
     )
     .groupBy('service_types.service_type_id');
 };
@@ -19,11 +35,14 @@ const findById = async (id) => {
     .leftJoin('service_providers', {
       'service_types.service_type_id': 'service_providers.service_type_id',
     })
+    .leftJoin('programs', {
+      'service_types.program_id': 'programs.program_id', 
+    })
     .leftJoin('profiles', {
       'service_providers.profile_id': 'profiles.profile_id',
     })
     .select(
-      knex.raw('service_types.*, json_agg(profiles.*) as service_providers')
+      knex.raw('service_types.service_type_id, service_types.name as service, service_types.description, array_agg(programs.name) as program, json_agg(profiles.*) as service_providers')
     )
     .where({ 'service_types.service_type_id': id })
     .groupBy('service_types.service_type_id')
@@ -57,7 +76,7 @@ const create = async (serviceType) => {
 
 const update = async (id, updates) => {
   // separate out the service_providers array for junction table insert
-  const { service_providers, ...serviceType } = updates;
+  const { service_providers_arr, ...serviceType } = updates;
 
   try {
     await knex.transaction(async (trx) => {
@@ -67,16 +86,19 @@ const update = async (id, updates) => {
       }
 
       // if request includes providers_array, wipe existing associations
-      if (service_providers) {
-        await trx('services_providers').where('service_type_id', id).delete();
+      if (service_providers_arr) {
+        await trx('service_providers').where('service_type_id', id).delete();
       }
       // then insert new associations if there are any
-      if (service_providers && service_providers.length > 0) {
-        await trx('services_providers').insert(
-          service_providers.map((p) => {
-            return { service_type_id: id, provider_id: p };
+      if (service_providers_arr && service_providers_arr.length > 0) {
+        while (service_providers_arr.length > 0){
+          console.log(service_providers_arr)
+          await knex('service_providers').insert({
+            service_type_id: newServiceTypeId,
+            profile_id: service_providers_arr[service_providers_arr.length - 1]
           })
-        );
+          service_providers_arr.pop()
+        }
       }
     });
     // return promise with the updated service type and associated providers

--- a/data/migrations/008_create-households.js
+++ b/data/migrations/008_create-households.js
@@ -1,0 +1,21 @@
+exports.up = function (knex) {
+  return knex.schema.createTable('households', function (tbl) {
+    tbl.increments('household_id').primary();
+    tbl.string('household_name', 128).notNullable().unique();
+    tbl.integer('household_size');
+    tbl.decimal('household_income');
+    tbl
+      .integer('location_id')
+      .unsigned()
+      .notNullable()
+      .references('location_id')
+      .inTable('locations')
+      .onUpdate('CASCADE')
+      .onDelete('CASCADE');
+    tbl.timestamps(true, true);
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.dropTableIfExists('households');
+};

--- a/data/migrations/008_create-recipients.js
+++ b/data/migrations/008_create-recipients.js
@@ -13,6 +13,13 @@ exports.up = function(knex) {
         .inTable('ethnicity')
         .onUpdate('CASCADE')
         .onDelete('CASCADE');
+        tbl
+        .integer('household_id')
+        .unsigned()
+        .references('household_id')
+        .inTable('households')
+        .onUpdate('CASCADE')
+        .onDelete('CASCADE');
         tbl.string('email', 128)
         tbl.string('phone', 128)
         tbl.integer('age').unsigned()

--- a/data/seeds/006_locations.js
+++ b/data/seeds/006_locations.js
@@ -1,0 +1,38 @@
+const locations = [
+  {
+    name: 'Smith Residence',
+    country: 'United States of America',
+    state: 'Washington',
+    city: 'Seattle',
+    zip: '98101',
+    address: '123 Terrance Ave',
+  },
+  {
+    name: 'California Mission',
+    country: 'United States of America',
+    state: 'California',
+    city: 'Los Angeles',
+    zip: '90001',
+    address: '5828 Carson Dr',
+  },
+  {
+    name: 'Massachusetts Shelter',
+    country: 'United States of America',
+    state: 'Massachusetts',
+    city: 'Boston',
+    zip: '01001',
+    address: '492 Beverley Way',
+  },
+  {
+    name: 'Jackson Residence',
+    country: 'United States of America',
+    state: 'Colorado',
+    city: 'Denver',
+    zip: '80013',
+    address: '9475 N Broadway Ave',
+  },
+];
+
+exports.seed = function (knex) {
+  return knex('locations').insert(locations);
+};

--- a/data/seeds/007_households.js
+++ b/data/seeds/007_households.js
@@ -1,0 +1,30 @@
+const households = [
+  {
+    household_name: "Smith's",
+    household_size: 5,
+    household_income: 42855.06,
+    location_id: 1,
+  },
+  {
+    household_name: "Gutierrez's",
+    household_size: 3,
+    household_income: 27832.02,
+    location_id: 2,
+  },
+  {
+    household_name: "Nguyen's",
+    household_size: 2,
+    household_income: 25657.12,
+    location_id: 3,
+  },
+  {
+    household_name: "Jacksons's",
+    household_size: 4,
+    household_income: 42855.06,
+    location_id: 4,
+  },
+];
+
+exports.seed = function (knex) {
+  return knex('households').insert(households);
+};

--- a/data/seeds/008_recipients.js
+++ b/data/seeds/008_recipients.js
@@ -1,0 +1,54 @@
+const recipients = [
+  {
+    firstname: 'Michael',
+    middle: 'Joseph',
+    lastname: 'Smith',
+    ethnicity_id: 1,
+    household_id: 1,
+    email: 'michaeljsmith87@gmail.com',
+    phone: '(555)555-5555',
+    age: 33,
+    veteran: true,
+    mental_status: '',
+  },
+  {
+    firstname: 'Jose',
+    middle: 'Guadalupe',
+    lastname: 'Gutierrez',
+    ethnicity_id: 2,
+    household_id: 2,
+    email: 'jgutierrez95@gmail.com',
+    phone: '(444)444-4444',
+    age: 26,
+    veteran: false,
+    mental_status: '',
+  },
+  {
+    firstname: 'Victoria',
+    middle: '',
+    lastname: 'Nguyen',
+    ethnicity_id: 3,
+    household_id: 3,
+    email: 'victorian90@gmail.com',
+    phone: '(333)333-3333',
+    age: 30,
+    veteran: false,
+    mental_status: '',
+  },
+  {
+    firstname: 'Andre',
+    middle: '',
+    lastname: 'Jackson',
+    ethnicity_id: 4,
+    household_id: 4,
+    email: 'ajackson85@gmail.com',
+    phone: '(222)222-2222',
+    age: 36,
+    veteran: true,
+    mental_status: '',
+  },
+];
+
+exports.seed = function (knex) {
+  return knex('recipients').insert(recipients);
+};


### PR DESCRIPTION
### Description
After our last stakeholder meeting I realized that we wont need multiple recipients attached to multiple households. So I simplified that part of the DB by removing the household_members table and just giving recipients a household_id from the households table. this way each recipient can only have 1 household, but 1 household can have many recipients. 

Because of this migration and seed change I had to change the recipient model to match this new household information by joining and returning the households that recipient is a part of, and the location of that household, This will be used later on for metrics regarding locations that services have taken place.

aside from these changes I lastly added an aggregate function into the serviceTypeModel query to properly pull in the name of the program. This does however bring a bug of putting that program name into an array rather than just a key value pair. I will look into fixing that but for now it will at least show the name of the program rather than the program_id.

Type of change
- [x]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [x]  This change requires a documentation update

Change Status
- [x]  Complete, but not tested (may need new tests)

Checklist
- [x] My code follows the style guidelines of this project
- [x]  I have performed a self-review of my own code
- [x]  My changes generate no new warnings
- [x]  There are no merge conflicts
