### PR TITLE
fixed auth issue on post

### DIFF
--- a/api/program/programRouter.js
+++ b/api/program/programRouter.js
@@ -5,7 +5,7 @@ const router = express.Router();
 const { canCrudServiceType } = require('../middleware/authorization');
 const { validateProgram } = require('./programMiddleware');
 
-router.get('/', canCrudServiceType, (req, res) => {
+router.get('/', (req, res) => {
   Programs.findAll()
     .then((programs) => {
       res.status(200).json(programs);
@@ -15,7 +15,7 @@ router.get('/', canCrudServiceType, (req, res) => {
     });
 });
 
-router.get('/:id', canCrudServiceType, (req, res) => {
+router.get('/:id', (req, res) => {
   const { id } = req.params;
 
   Programs.findById(id)
@@ -31,7 +31,7 @@ router.get('/:id', canCrudServiceType, (req, res) => {
     });
 });
 
-router.post('/', canCrudServiceType, validateProgram, (req, res) => {
+router.post('/', validateProgram, (req, res) => {
   DB.create('programs', req.body)
     .then((newProgram) => {
       res.status(201).json(newProgram);


### PR DESCRIPTION
Made middleware stop checking for program_id when it is not necessary, to be more widely applicable. Also made it check for profile in the correct area and stopped it from referring to another middleware which would break with our updated db schema. Should now successfully post but only if admin or program_manager.

Type of change
☑︎ Bug fix (non-breaking change which fixes an issue)
☑︎ New feature (non-breaking change which adds functionality)
☑︎ This change requires a documentation update
Change Status
☑︎ Complete, but not tested (may need new tests)
Checklist
☑︎ My code follows the style guidelines of this project
☑︎ I have performed a self-review of my own code
☑︎ My changes generate no new warnings
☑︎ There are no merge conflicts